### PR TITLE
Add missing ProtocolAttribute.

### DIFF
--- a/binding/ApiDefinition.cs
+++ b/binding/ApiDefinition.cs
@@ -117,7 +117,7 @@ namespace MonoTouch.TTTAttributedLabel {
 	}
 
 	[BaseType (typeof (NSObject))]
-	[Model]
+	[Model][Protocol]
 	public partial interface TTTAttributedLabelDelegate {
 
 		[Export ("attributedLabel:didSelectLinkWithURL:")]


### PR DESCRIPTION
Xamarin.iOS was complaining about the missing Protocol attribute when
compiling for the device.
